### PR TITLE
introduce blank? and present? method to make checking for blank values easier

### DIFF
--- a/lib/secretariat.rb
+++ b/lib/secretariat.rb
@@ -16,7 +16,6 @@ limitations under the License.
 
 require_relative 'secretariat/version'
 require_relative 'secretariat/object_extensions'
-# using Secretariat::ObjectExtensions
 require_relative 'secretariat/constants'
 require_relative 'secretariat/helpers'
 require_relative 'secretariat/versioner'

--- a/lib/secretariat.rb
+++ b/lib/secretariat.rb
@@ -15,6 +15,8 @@ limitations under the License.
 =end
 
 require_relative 'secretariat/version'
+require_relative 'secretariat/object_extensions'
+# using Secretariat::ObjectExtensions
 require_relative 'secretariat/constants'
 require_relative 'secretariat/helpers'
 require_relative 'secretariat/versioner'

--- a/lib/secretariat/invoice.rb
+++ b/lib/secretariat/invoice.rb
@@ -289,7 +289,7 @@ module Secretariat
                 xml['ram'].ApplicableTradeTax do
                   Helpers.currency_element(xml, 'ram', 'CalculatedAmount', tax.tax_amount, currency_code, add_currency: version == 1)
                   xml['ram'].TypeCode 'VAT'
-                  unless tax_reason_text.blank?
+                  if tax_reason_text.present?
                     xml['ram'].ExemptionReason tax_reason_text
                   end
                   Helpers.currency_element(xml, 'ram', 'BasisAmount', tax.base_amount, currency_code, add_currency: version == 1)

--- a/lib/secretariat/invoice.rb
+++ b/lib/secretariat/invoice.rb
@@ -17,6 +17,8 @@ limitations under the License.
 require 'bigdecimal'
 
 module Secretariat
+  using ObjectExtensions
+  
   Invoice = Struct.new("Invoice",
     :id,
     :issue_date,
@@ -268,14 +270,16 @@ module Secretariat
             end
             trade_settlement = by_version(version, 'ApplicableSupplyChainTradeSettlement', 'ApplicableHeaderTradeSettlement')
             xml['ram'].send(trade_settlement) do
-              if payment_reference && payment_reference != ''
+              unless payment_reference.blank?
                 xml['ram'].PaymentReference payment_reference
               end
               xml['ram'].InvoiceCurrencyCode currency_code
               xml['ram'].SpecifiedTradeSettlementPaymentMeans do
                 xml['ram'].TypeCode payment_code
-                xml['ram'].Information payment_text if payment_text && payment_text != ''
-                if payment_iban && payment_iban != ''
+                unless payment_text.blank?
+                  xml['ram'].Information payment_text
+                end
+                unless payment_iban.blank?
                   xml['ram'].PayeePartyCreditorFinancialAccount do
                     xml['ram'].IBANID payment_iban
                   end
@@ -285,7 +289,7 @@ module Secretariat
                 xml['ram'].ApplicableTradeTax do
                   Helpers.currency_element(xml, 'ram', 'CalculatedAmount', tax.tax_amount, currency_code, add_currency: version == 1)
                   xml['ram'].TypeCode 'VAT'
-                  if tax_reason_text && tax_reason_text != ''
+                  unless tax_reason_text.blank?
                     xml['ram'].ExemptionReason tax_reason_text
                   end
                   Helpers.currency_element(xml, 'ram', 'BasisAmount', tax.base_amount, currency_code, add_currency: version == 1)

--- a/lib/secretariat/invoice.rb
+++ b/lib/secretariat/invoice.rb
@@ -18,7 +18,7 @@ require 'bigdecimal'
 
 module Secretariat
   using ObjectExtensions
-  
+
   Invoice = Struct.new("Invoice",
     :id,
     :issue_date,
@@ -270,16 +270,16 @@ module Secretariat
             end
             trade_settlement = by_version(version, 'ApplicableSupplyChainTradeSettlement', 'ApplicableHeaderTradeSettlement')
             xml['ram'].send(trade_settlement) do
-              unless payment_reference.blank?
+              if payment_reference.present?
                 xml['ram'].PaymentReference payment_reference
               end
               xml['ram'].InvoiceCurrencyCode currency_code
               xml['ram'].SpecifiedTradeSettlementPaymentMeans do
                 xml['ram'].TypeCode payment_code
-                unless payment_text.blank?
+                if payment_text.present?
                   xml['ram'].Information payment_text
                 end
-                unless payment_iban.blank?
+                if payment_iban.present?
                   xml['ram'].PayeePartyCreditorFinancialAccount do
                     xml['ram'].IBANID payment_iban
                   end

--- a/lib/secretariat/object_extensions.rb
+++ b/lib/secretariat/object_extensions.rb
@@ -1,0 +1,10 @@
+module Secretariat
+  module ObjectExtensions
+    refine Object do
+      # Copied from activesupport/lib/active_support/core_ext/object/blank.rb, line 18
+      def blank?
+        respond_to?(:empty?) ? !!empty? : !self
+      end
+    end
+  end
+end

--- a/lib/secretariat/object_extensions.rb
+++ b/lib/secretariat/object_extensions.rb
@@ -5,6 +5,10 @@ module Secretariat
       def blank?
         respond_to?(:empty?) ? !!empty? : !self
       end
+
+      def present?
+        !blank?
+      end
     end
   end
 end


### PR DESCRIPTION
Copy over [`blank?`](https://devdocs.io/rails~7.0/object#method-i-blank-3F) and `present?` methods from Rails to avoid the cumbersome check `if value && value != ''`