### PR TITLE
align line_total_amount with quantity

### DIFF
--- a/lib/secretariat/line_item.rb
+++ b/lib/secretariat/line_item.rb
@@ -208,7 +208,8 @@ module Secretariat
           end
           monetary_summation = by_version(version, 'SpecifiedTradeSettlementMonetarySummation', 'SpecifiedTradeSettlementLineMonetarySummation')
           xml['ram'].send(monetary_summation) do
-            Helpers.currency_element(xml, 'ram', 'LineTotalAmount', (quantity.negative? ? -charge_amount : charge_amount), currency_code, add_currency: version == 1)
+            charge_amount_abs = BigDecimal(charge_amount).abs
+            Helpers.currency_element(xml, 'ram', 'LineTotalAmount', (quantity.negative? ? -charge_amount_abs : charge_amount_abs), currency_code, add_currency: version == 1)
           end
         end
 


### PR DESCRIPTION
LineTotalAmount sign must be same with quantity.

the problem occurred, when charge_amount and quantity set as negative.
so before code will reverse charge_amount to positive.

with new code, LineTotalAmount sign will align with quantity sign.